### PR TITLE
Porting to Gtk3 and fixing vte failure

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,5 +16,5 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
-from sugar.activity import bundlebuilder
+from sugar3.activity import bundlebuilder
 bundlebuilder.start('VncLauncher')


### PR DESCRIPTION
 The activity was in gtk and the conversion to sugar3 assumed no changes were needed between vte and Vte.

 Porting to Gtk3 and making the desired changes.

 Fixes https://github.com/sugarlabs/VncLauncher/issues/3 https://github.com/sugarlabs/VncLauncher/issues/2